### PR TITLE
🚀 Feature/runid copy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ jobs:
         - name: Get repo name
           run: echo "REPO_NAME=${{ github.event.repository.name }}" >> $GITHUB_ENV
           
-	- name: Get run id
+	      - name: Get run id
           if: ${{ github.event_name == 'pull_request' &&  github.event.action == 'opened'}}
           run: echo "RUN_ID=1" >> $GITHUB_ENV 
 	  
@@ -106,7 +106,7 @@ jobs:
             current-branch-name: ${{ env.BRANCH_NAME }}
             tag-name: ${{ env.TAG_NAME }} 
             org-name: '<github-organization-name>'
-	    run-id: ${{ env.RUN_ID }} 
+	          run-id: ${{ env.RUN_ID }} 
 
   preview-link:
     runs-on: self-hosted
@@ -118,5 +118,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           prDescAppend: "${{ needs.deploy-theme.outputs.preview-link }}"
-          isTicketUpdate: false #true, for set jira link on pr-description           
+          isTicketUpdate: false #true, for set jira link on           
 ```            

--- a/README.md
+++ b/README.md
@@ -79,7 +79,11 @@ jobs:
 
         - name: Get repo name
           run: echo "REPO_NAME=${{ github.event.repository.name }}" >> $GITHUB_ENV
-          
+
+        - name: Get run id
+          if: ${{ github.event_name == 'pull_request' &&  github.event.action == 'opened'}}
+          run: echo "RUN_ID=1" >> $GITHUB_ENV  
+
         - name: Convert secrets to JSON
           id: create-json
           uses: jsdaniell/create-json@1.1.2
@@ -102,6 +106,7 @@ jobs:
             current-branch-name: ${{ env.BRANCH_NAME }}
             tag-name: ${{ env.TAG_NAME }} 
             org-name: '<github-organization-name>'
+            run-id: ${{ env.RUN_ID }} 
 
   preview-link:
     runs-on: self-hosted

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This centralized GitHub action deploys a theme to shopify admin
     current-branch-name: ${{ env.BRANCH_NAME }}
     tag-name: ${{ env.TAG_NAME }} 
     org-name: '<github-organization-name>'
+    run-id: <integer>  # To copy setting from main the first time a PR is created, if the settings doesn't exist on github 
 ```
 
 Theme credentials can be stored as GitHub secrets as: 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ jobs:
 
         - name: Get repo name
           run: echo "REPO_NAME=${{ github.event.repository.name }}" >> $GITHUB_ENV
-	  
+          
         - name: Convert secrets to JSON
           id: create-json
           uses: jsdaniell/create-json@1.1.2

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In order to convert the theme secrets to JSON use the following action:
 Combining above two with generating environment variables, the complete workflow would look like: 
 
 ```YAML
-name: deploy theme
+name: Deploy theme
 
 on:
   pull_request:
@@ -80,6 +80,10 @@ jobs:
         - name: Get repo name
           run: echo "REPO_NAME=${{ github.event.repository.name }}" >> $GITHUB_ENV
           
+	- name: Get run id
+          if: ${{ github.event_name == 'pull_request' &&  github.event.action == 'opened'}}
+          run: echo "RUN_ID=1" >> $GITHUB_ENV 
+	  
         - name: Convert secrets to JSON
           id: create-json
           uses: jsdaniell/create-json@1.1.2
@@ -102,6 +106,7 @@ jobs:
             current-branch-name: ${{ env.BRANCH_NAME }}
             tag-name: ${{ env.TAG_NAME }} 
             org-name: '<github-organization-name>'
+	    run-id: ${{ env.RUN_ID }} 
 
   preview-link:
     runs-on: self-hosted

--- a/README.md
+++ b/README.md
@@ -79,10 +79,6 @@ jobs:
 
         - name: Get repo name
           run: echo "REPO_NAME=${{ github.event.repository.name }}" >> $GITHUB_ENV
-          
-	      - name: Get run id
-          if: ${{ github.event_name == 'pull_request' &&  github.event.action == 'opened'}}
-          run: echo "RUN_ID=1" >> $GITHUB_ENV 
 	  
         - name: Convert secrets to JSON
           id: create-json
@@ -106,7 +102,6 @@ jobs:
             current-branch-name: ${{ env.BRANCH_NAME }}
             tag-name: ${{ env.TAG_NAME }} 
             org-name: '<github-organization-name>'
-	          run-id: ${{ env.RUN_ID }} 
 
   preview-link:
     runs-on: self-hosted

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
   org-name:
     description: Name of the github organization
     required: false 
+  run-id:
+    description: Number of times a PR build has ran
+    required: false 
 
 outputs:
   preview-link:  # id of output
@@ -73,6 +76,7 @@ runs:
         WORK_DIR: ${{ inputs.theme-files-location }} 
         BRANCH_NAME: ${{ inputs.current-branch-name }} 
         TAG_NAME: ${{ inputs.tag-name }}
+        RUN_ID: ${{ inputs.run-id }}
       run: |
         if [[ "${{ inputs.current-branch-name }}" != 'main' ]] || [[ -n "${{ inputs.tag-name }}" ]]; then 
           ${{ github.action_path }}/scripts/DeployPRorTag.sh

--- a/action.yml
+++ b/action.yml
@@ -4,67 +4,67 @@ description: Deploys theme(s) to shopify store(s)
 inputs:
   store-name:
     description: Name of the store
-    required: true 
+    required: true
   theme-env:
     description: Name of the environment for theme deployment
-    required: true 
+    required: true
   copy-settings:
     description: Parameter to check if the setting need to copy
-    required: false   
-    default: "false" 
+    required: false
+    default: "false"
   main-theme-id:
     description: ID of main theme
-    required: false  
+    required: false
   repo-name:
     description: Name of the current repo
     required: false
   github-token:
     description: Token for graphl calls
-    required: false     
+    required: false
   shopify-api-version:
     description: Shopify api version
     required: true
   theme-files-location:
-    description: location of all the theme files 
+    description: location of all the theme files
     required: false
-  current-branch-name: 
-    description: Provides current branch name 
-    required: false  
-  tag-name: 
+  current-branch-name:
+    description: Provides current branch name
+    required: false
+  tag-name:
     description: Provides current tag name
-    required: false  
+    required: false
   org-name:
     description: Name of the github organization
-    required: false 
+    required: false
   run-id:
     description: Number of times a PR build has ran
-    required: false 
+    required: false
 
 outputs:
-  preview-link:  # id of output
-    description: 'Theme preview link'
-    value:  ${{ steps.deploy-pr.outputs.preview_link }}
-  theme_id:  
-    description: 'ID of theme created, used for lighthouse check'
-    value:  ${{ steps.deploy-pr.outputs.theme_id }}
-    
+  preview-link: # id of output
+    description: "Theme preview link"
+    value: ${{ steps.deploy-pr.outputs.preview_link }}
+  theme_id:
+    description: "ID of theme created, used for lighthouse check"
+    value: ${{ steps.deploy-pr.outputs.theme_id }}
+
 runs:
   using: "composite"
   steps:
     - name: Delete Old Themes
       env:
         STORE_NAME: ${{ inputs.store-name }}
-        REPO_NAME: ${{ inputs.repo-name }} 
-        GITHUB_TOKEN: ${{ inputs.github-token }} 
-        SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }} 
-        BRANCH_NAME: ${{ inputs.current-branch-name }} 
+        REPO_NAME: ${{ inputs.repo-name }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
+        BRANCH_NAME: ${{ inputs.current-branch-name }}
         TAG_NAME: ${{ inputs.tag-name }}
         ORG_NAME: ${{ inputs.org-name }}
       run: |
         if [[ -z "${{ inputs.tag-name }}" ]]; then
           ${{ github.action_path }}/scripts/DeleteInactiveThemes.sh 
-        fi   
-      shell: bash  
+        fi
+      shell: bash
 
     - name: Deploy a PR or a Tag
       id: deploy-pr
@@ -73,26 +73,27 @@ runs:
         THEME_ENV: ${{ inputs.theme-env }}
         COPY_SETTINGS: ${{ inputs.copy-settings }}
         SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
-        WORK_DIR: ${{ inputs.theme-files-location }} 
-        BRANCH_NAME: ${{ inputs.current-branch-name }} 
+        WORK_DIR: ${{ inputs.theme-files-location }}
+        BRANCH_NAME: ${{ inputs.current-branch-name }}
         TAG_NAME: ${{ inputs.tag-name }}
         RUN_ID: ${{ inputs.run-id }}
       run: |
         if [[ "${{ inputs.current-branch-name }}" != 'main' ]] || [[ -n "${{ inputs.tag-name }}" ]]; then 
           ${{ github.action_path }}/scripts/DeployPRorTag.sh
-        fi   
-      shell: bash  
+        fi
+      shell: bash
 
     - name: Deploy Main
-      env:  
+      env:
         STORE_NAME: ${{ inputs.store-name }}
         BRANCH_NAME: ${{ inputs.current-branch-name }}
+        COPY_SETTINGS: ${{ inputs.copy-settings }}
         MAIN_THEME_IDS: ${{ inputs.main-theme-id }}
-        THEME_ENV: ${{ inputs.theme-env }} 
-        SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }} 
+        THEME_ENV: ${{ inputs.theme-env }}
+        SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
         WORK_DIR: ${{ inputs.theme-files-location }}
       run: |
-          if [[ "${{ inputs.current-branch-name }}" == 'main' ]]; then
-            ${{ github.action_path }}/scripts/DeployMain.sh
-          fi  
-      shell: bash  
+        if [[ "${{ inputs.current-branch-name }}" == 'main' ]]; then
+          ${{ github.action_path }}/scripts/DeployMain.sh
+        fi
+      shell: bash

--- a/scripts/DeployMain.sh
+++ b/scripts/DeployMain.sh
@@ -22,16 +22,23 @@ function deploy_main_branch(){
         -X PUT "https://${STORE_NAME}.myshopify.com/admin/api/${SHOPIFY_API_VERSION}/themes/${THEME_ID}.json" \
         -H "X-Shopify-Access-Token: ${THEMEKIT_PASSWORD}" \
         -H "Content-Type: application/json" 
-  #Deploy to live
-  theme -e ${THEME_ENV} deploy --allow-live; STATUS1=$?
- 
+
+  # Deploy to live
+    if [[ $COPY_SETTINGS == true ]]  
+    then   
+        echo "ignoring current PR's settings"
+        theme -e ${THEME_ENV} deploy --allow-live --ignored-file=config/settings_data.json; STATUS1=$? 
+    else
+          theme -e ${THEME_ENV} deploy --allow-live; STATUS1=$?    
+    fi
+
   
   # Return the status code of theme commands
   TOTAL=$((STATUS1 + STATUS2))
   if [[ $TOTAL != 0 ]]
     then 
-       echo "Failing deployment"
-       exit $TOTAL
+        echo "Failing deployment"
+        exit $TOTAL
     fi 
     
   cd ..

--- a/scripts/DeployMain.sh
+++ b/scripts/DeployMain.sh
@@ -26,10 +26,10 @@ function deploy_main_branch(){
   # Deploy to live
     if [[ $COPY_SETTINGS == true ]]  
     then   
-        echo "ignoring current PR's settings"
+        echo "======= Ignoring merged PR's settings ========"
         theme -e ${THEME_ENV} deploy --allow-live --ignored-file=config/settings_data.json; STATUS1=$? 
     else
-          theme -e ${THEME_ENV} deploy --allow-live; STATUS1=$?    
+        theme -e ${THEME_ENV} deploy --allow-live; STATUS1=$?    
     fi
 
   

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -37,11 +37,11 @@ deploy_pr_branch_or_tag() {
         configure_theme
     fi
 
-    if [[ $COPY_SETTINGS == true ]] && [[ -n $RUN_ID]]
-    then   
+    if [[ $COPY_SETTINGS == true ]] && [[ -n $RUN_ID ]]; then   
         echo "Copy settings"
-        theme download --password=${THEMEKIT_PASSWORD} --store="${STORE_NAME}.myshopify.com"  --env ${THEME_ENV} config/settings_data.json --live; STATUS1=$?
-    fi 
+        theme download --password=${THEMEKIT_PASSWORD} --store="${STORE_NAME}.myshopify.com" --env ${THEME_ENV} config/settings_data.json --live; STATUS1=$?
+    fi
+
    
     # Return the status code of theme commands
     TOTAL=$((STATUS1 + STATUS2))

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -42,7 +42,7 @@ deploy_pr_branch_or_tag() {
         theme download --password=${THEMEKIT_PASSWORD} --store="${STORE_NAME}.myshopify.com" --env ${THEME_ENV} config/settings_data.json --live; STATUS1=$?
     fi
 
-   
+
     # Return the status code of theme commands
     TOTAL=$((STATUS1 + STATUS2))
 

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -37,7 +37,7 @@ deploy_pr_branch_or_tag() {
         configure_theme
     fi
 
-    if [[ $COPY_SETTINGS == true ]]
+    if [[ $COPY_SETTINGS == true ]] && [[ -n $RUN_ID]]
     then   
         echo "Copy settings"
         theme download --password=${THEMEKIT_PASSWORD} --store="${STORE_NAME}.myshopify.com"  --env ${THEME_ENV} config/settings_data.json --live; STATUS1=$?


### PR DESCRIPTION
- Added an extra parameter `RUN_ID` so that we know if a PR is running for the first time, we copy the settings from live theme. If we don't pass this parameter, or set `copy_settings: false`, they wont get copied over 
- Added the same logic for Main branch deployment, but just with copy settings. 
- This is needed for client like shape, where we don't store settings file in github as they have multiple stores 
- Tested on https://github.com/SatelCreative/st_theme/commit/6a3fc63ac404de3c190a58585ce49c6ef5201948
- Closes: https://github.com/SatelCreative/DevOps-IT/issues/243