### PR TITLE
replace set output with github o/p

### DIFF
--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -95,5 +95,5 @@ done
 
 echo "THEME_ID=${THEME_IDS[@]}"
 # These outputs are used in other steps/jobs via action.yml
-echo "::set-output name=preview_link::${PREVIEW_LINKS[@]}" 
-echo "::set-output name=theme_id::${THEME_IDS[@]}" 
+echo "preview_link=${PREVIEW_LINKS[@]}" >> $GITHUB_OUTPUT
+echo "theme_id=${THEME_IDS[@]}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fix for 
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/