### PR TITLE
Multiple config profile options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ A reusable GitHub Action to deploy Shopify themes across multiple environments a
 
 - Copies published theme settings when needed
 
-- Works with multiple `config.yml` profiles 
+- Works with multiple `config.yml` profiles by temporary modifying `config.yml.example`
 
 - Integrates with CI/CD workflows and Slack
 
 - Works with GitHub-hosted and self-hosted runners
+
 
 
 ## 🔧 Usage
@@ -113,6 +114,28 @@ jobs:
       SELF_HOSTED_RUNNER_TOKEN: ${{ secrets.SELF_HOSTED_RUNNER_TOKEN }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
+
+`config.yml.example` would like this: 
+
+```YAML
+downloadPublishedSettings:
+  password: API_KEY
+  theme_id: THEME_ID # This is not being used while deployment
+  store: STORE
+  ignore_files:
+    - sections/*.liquid
+    - snippets/*
+    - assets/*
+    - config/settings_schema.json
+    - layout/*
+    - locales/*
+
+deployTheme:
+  password: API_KEY
+  theme_id: TARGET_THEME_ID # Theme GitHub is deploying to
+  store: STORE
+  ```
+
 📘 **Notes**
 - API Key should be stored securely (e.g., in LastPass). It must come from a Shopify Custom App with theme read/write access. Name the app as `CI CD` on Shopify
 

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
     description: Name of the current repo
     required: false
   github-token:
-    description: Token for graphl calls
+    description: Token for GraphQL calls
     required: false
   # https://shopify.dev/docs/api/admin-rest/2025-04/resources/theme  
   shopify-api-version:

--- a/action.yml
+++ b/action.yml
@@ -73,9 +73,6 @@ runs:
 
     - name: Deploy a PR or a Tag
       id: deploy-pr
-      # Only run on 1st commit, as per Alex rest of the commit 
-      # will be done directly on SHopify first as bug fixes
-      if: ${{ inputs.run-id == '1' }}
       env:
         STORE_NAME: ${{ inputs.store-name }}
         THEME_ENV: ${{ inputs.theme-env }}
@@ -85,10 +82,12 @@ runs:
         BRANCH_NAME: ${{ inputs.current-branch-name }}
         TAG_NAME: ${{ inputs.tag-name }}
         RUN_ID: ${{ inputs.run-id }}
+        # Only run on 1st commit, as per Alex rest of the commit 
+        # will be done directly on SHopify first as bug fixes  
       run: |
-        if [[ "${{ inputs.current-branch-name }}" != 'main' ]] || [[ -n "${{ inputs.tag-name }}" ]]; then 
-          ${{ github.action_path }}/scripts/DeployPRorTag.sh
-        fi
+          if [[ "${{ inputs.run-id }}" == "1" ]] && ([[ "${{ inputs.current-branch-name }}" != "main" ]] || [[ -n "${{ inputs.tag-name }}" ]]); then 
+            ${{ github.action_path }}/scripts/DeployPRorTag.sh
+          fi
       shell: bash
 
     - name: Deploy Main

--- a/action.yml
+++ b/action.yml
@@ -21,10 +21,11 @@ inputs:
   github-token:
     description: Token for graphl calls
     required: false
+  # https://shopify.dev/docs/api/admin-rest/2025-04/resources/theme  
   shopify-api-version:
     description: Shopify api version
     required: false
-    default: "2024-01"
+    default: "2025-04"
   theme-files-location:
     description: location of all the theme files
     required: false

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,6 @@ inputs:
   theme-env:
     description: Name of the environment for theme deployment
     required: true
-  copy-settings:
-    description: Parameter to check if the setting need to copy
-    required: false
-    default: "false"
   main-theme-id:
     description: ID of main theme
     required: false
@@ -80,7 +76,6 @@ runs:
       env:
         STORE_NAME: ${{ inputs.store-name }}
         THEME_ENV: ${{ inputs.theme-env }}
-        COPY_SETTINGS: ${{ inputs.copy-settings }}
         SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
         WORK_DIR: ${{ inputs.theme-files-location }}
         BRANCH_NAME: ${{ inputs.current-branch-name }}
@@ -95,7 +90,6 @@ runs:
       env:
         STORE_NAME: ${{ inputs.store-name }}
         BRANCH_NAME: ${{ inputs.current-branch-name }}
-        COPY_SETTINGS: ${{ inputs.copy-settings }}
         MAIN_THEME_IDS: ${{ inputs.main-theme-id }}
         THEME_ENV: ${{ inputs.theme-env }}
         SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}

--- a/action.yml
+++ b/action.yml
@@ -55,24 +55,27 @@ outputs:
 runs:
   using: "composite"
   steps:
-    # - name: Delete Old Themes
-    #   env:
-    #     STORE_NAME: ${{ inputs.store-name }}
-    #     REPO_NAME: ${{ inputs.repo-name }}
-    #     GITHUB_TOKEN: ${{ inputs.github-token }}
-    #     SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
-    #     WORK_DIR: ${{ inputs.theme-files-location }}
-    #     BRANCH_NAME: ${{ inputs.current-branch-name }}
-    #     TAG_NAME: ${{ inputs.tag-name }}
-    #     ORG_NAME: ${{ inputs.org-name }}
-    #   run: |
-    #     if [[ -z "${{ inputs.tag-name }}" ]]; then
-    #       ${{ github.action_path }}/scripts/DeleteInactiveThemes.sh 
-    #     fi
-    #   shell: bash
+    - name: Delete Old Themes
+      env:
+        STORE_NAME: ${{ inputs.store-name }}
+        REPO_NAME: ${{ inputs.repo-name }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
+        WORK_DIR: ${{ inputs.theme-files-location }}
+        BRANCH_NAME: ${{ inputs.current-branch-name }}
+        TAG_NAME: ${{ inputs.tag-name }}
+        ORG_NAME: ${{ inputs.org-name }}
+      run: |
+        if [[ -z "${{ inputs.tag-name }}" ]]; then
+          ${{ github.action_path }}/scripts/DeleteInactiveThemes.sh 
+        fi
+      shell: bash
 
     - name: Deploy a PR or a Tag
       id: deploy-pr
+      # Only run on 1st commit, as per Alex rest of the commit 
+      # will be done directly on SHopify first as bug fixes
+      if: ${{ inputs.run-id == '1' }}
       env:
         STORE_NAME: ${{ inputs.store-name }}
         THEME_ENV: ${{ inputs.theme-env }}

--- a/action.yml
+++ b/action.yml
@@ -72,37 +72,37 @@ runs:
         fi
       shell: bash
 
-    # - name: Deploy a PR or a Tag
-    #   id: deploy-pr
-    #   # Only run on the 1st commit, as per Alex. 
-    #   # The rest will be done directly on Shopify as bug fixes.
-    #   if: ${{ inputs.run-id == '1' }}
-    #   env:
-    #     STORE_NAME: ${{ inputs.store-name }}
-    #     THEME_ENV: ${{ inputs.theme-env }}
-    #     COPY_SETTINGS: ${{ inputs.copy-settings }}
-    #     SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
-    #     WORK_DIR: ${{ inputs.theme-files-location }}
-    #     BRANCH_NAME: ${{ inputs.current-branch-name }}
-    #     TAG_NAME: ${{ inputs.tag-name }}
-    #   run: |
-    #     if [[ "${{ inputs.current-branch-name }}" != "main" ]] || [[ -n "${{ inputs.tag-name }}" ]]; then 
-    #       ${{ github.action_path }}/scripts/DeployPRorTag.sh
-    #     fi
-    #   shell: bash
+    - name: Deploy a PR or a Tag
+      id: deploy-pr
+      # Only run on the 1st commit, as per Alex. 
+      # The rest will be done directly on Shopify as bug fixes.
+      if: ${{ inputs.run-id == '1' }}
+      env:
+        STORE_NAME: ${{ inputs.store-name }}
+        THEME_ENV: ${{ inputs.theme-env }}
+        COPY_SETTINGS: ${{ inputs.copy-settings }}
+        SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
+        WORK_DIR: ${{ inputs.theme-files-location }}
+        BRANCH_NAME: ${{ inputs.current-branch-name }}
+        TAG_NAME: ${{ inputs.tag-name }}
+      run: |
+        if [[ "${{ inputs.current-branch-name }}" != "main" ]] || [[ -n "${{ inputs.tag-name }}" ]]; then 
+          ${{ github.action_path }}/scripts/DeployPRorTag.sh
+        fi
+      shell: bash
 
-    # - name: Deploy Main
-    #   env:
-    #     STORE_NAME: ${{ inputs.store-name }}
-    #     BRANCH_NAME: ${{ inputs.current-branch-name }}
-    #     COPY_SETTINGS: ${{ inputs.copy-settings }}
-    #     MAIN_THEME_IDS: ${{ inputs.main-theme-id }}
-    #     THEME_ENV: ${{ inputs.theme-env }}
-    #     SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
-    #     WORK_DIR: ${{ inputs.theme-files-location }}
-    #     PRD_PARAMETER: ${{ inputs.is-prd }}
-    #   run: |
-    #     if [[ "${{ inputs.current-branch-name }}" == 'main' ]]; then
-    #       ${{ github.action_path }}/scripts/DeployMain.sh
-    #     fi
-    #   shell: bash
+    - name: Deploy Main
+      env:
+        STORE_NAME: ${{ inputs.store-name }}
+        BRANCH_NAME: ${{ inputs.current-branch-name }}
+        COPY_SETTINGS: ${{ inputs.copy-settings }}
+        MAIN_THEME_IDS: ${{ inputs.main-theme-id }}
+        THEME_ENV: ${{ inputs.theme-env }}
+        SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
+        WORK_DIR: ${{ inputs.theme-files-location }}
+        PRD_PARAMETER: ${{ inputs.is-prd }}
+      run: |
+        if [[ "${{ inputs.current-branch-name }}" == 'main' ]]; then
+          ${{ github.action_path }}/scripts/DeployMain.sh
+        fi
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -55,21 +55,21 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Delete Old Themes
-      env:
-        STORE_NAME: ${{ inputs.store-name }}
-        REPO_NAME: ${{ inputs.repo-name }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-        SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
-        WORK_DIR: ${{ inputs.theme-files-location }}
-        BRANCH_NAME: ${{ inputs.current-branch-name }}
-        TAG_NAME: ${{ inputs.tag-name }}
-        ORG_NAME: ${{ inputs.org-name }}
-      run: |
-        if [[ -z "${{ inputs.tag-name }}" ]]; then
-          ${{ github.action_path }}/scripts/DeleteInactiveThemes.sh 
-        fi
-      shell: bash
+    # - name: Delete Old Themes
+    #   env:
+    #     STORE_NAME: ${{ inputs.store-name }}
+    #     REPO_NAME: ${{ inputs.repo-name }}
+    #     GITHUB_TOKEN: ${{ inputs.github-token }}
+    #     SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
+    #     WORK_DIR: ${{ inputs.theme-files-location }}
+    #     BRANCH_NAME: ${{ inputs.current-branch-name }}
+    #     TAG_NAME: ${{ inputs.tag-name }}
+    #     ORG_NAME: ${{ inputs.org-name }}
+    #   run: |
+    #     if [[ -z "${{ inputs.tag-name }}" ]]; then
+    #       ${{ github.action_path }}/scripts/DeleteInactiveThemes.sh 
+    #     fi
+    #   shell: bash
 
     - name: Deploy a PR or a Tag
       id: deploy-pr

--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,9 @@ runs:
 
     - name: Deploy a PR or a Tag
       id: deploy-pr
+      # Only run on the 1st commit, as per Alex. 
+      # The rest will be done directly on Shopify as bug fixes.
+      if: ${{ inputs.run-id == '1' }}
       env:
         STORE_NAME: ${{ inputs.store-name }}
         THEME_ENV: ${{ inputs.theme-env }}
@@ -81,14 +84,12 @@ runs:
         WORK_DIR: ${{ inputs.theme-files-location }}
         BRANCH_NAME: ${{ inputs.current-branch-name }}
         TAG_NAME: ${{ inputs.tag-name }}
-        RUN_ID: ${{ inputs.run-id }}
-        # Only run on 1st commit, as per Alex rest of the commit 
-        # will be done directly on SHopify first as bug fixes  
       run: |
-          if [[ "${{ inputs.run-id }}" == "1" ]] && ([[ "${{ inputs.current-branch-name }}" != "main" ]] || [[ -n "${{ inputs.tag-name }}" ]]); then 
-            ${{ github.action_path }}/scripts/DeployPRorTag.sh
-          fi
+        if [[ "${{ inputs.current-branch-name }}" != "main" ]] || [[ -n "${{ inputs.tag-name }}" ]]; then 
+          ${{ github.action_path }}/scripts/DeployPRorTag.sh
+        fi
       shell: bash
+
 
     - name: Deploy Main
       env:

--- a/action.yml
+++ b/action.yml
@@ -71,37 +71,37 @@ runs:
         fi
       shell: bash
 
-    - name: Deploy a PR or a Tag
-      id: deploy-pr
-      # Only run on the 1st commit, as per Alex. 
-      # The rest will be done directly on Shopify as bug fixes.
-      if: ${{ inputs.run-id == '1' }}
-      env:
-        STORE_NAME: ${{ inputs.store-name }}
-        THEME_ENV: ${{ inputs.theme-env }}
-        COPY_SETTINGS: ${{ inputs.copy-settings }}
-        SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
-        WORK_DIR: ${{ inputs.theme-files-location }}
-        BRANCH_NAME: ${{ inputs.current-branch-name }}
-        TAG_NAME: ${{ inputs.tag-name }}
-      run: |
-        if [[ "${{ inputs.current-branch-name }}" != "main" ]] || [[ -n "${{ inputs.tag-name }}" ]]; then 
-          ${{ github.action_path }}/scripts/DeployPRorTag.sh
-        fi
-      shell: bash
+    # - name: Deploy a PR or a Tag
+    #   id: deploy-pr
+    #   # Only run on the 1st commit, as per Alex. 
+    #   # The rest will be done directly on Shopify as bug fixes.
+    #   if: ${{ inputs.run-id == '1' }}
+    #   env:
+    #     STORE_NAME: ${{ inputs.store-name }}
+    #     THEME_ENV: ${{ inputs.theme-env }}
+    #     COPY_SETTINGS: ${{ inputs.copy-settings }}
+    #     SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
+    #     WORK_DIR: ${{ inputs.theme-files-location }}
+    #     BRANCH_NAME: ${{ inputs.current-branch-name }}
+    #     TAG_NAME: ${{ inputs.tag-name }}
+    #   run: |
+    #     if [[ "${{ inputs.current-branch-name }}" != "main" ]] || [[ -n "${{ inputs.tag-name }}" ]]; then 
+    #       ${{ github.action_path }}/scripts/DeployPRorTag.sh
+    #     fi
+    #   shell: bash
 
-    - name: Deploy Main
-      env:
-        STORE_NAME: ${{ inputs.store-name }}
-        BRANCH_NAME: ${{ inputs.current-branch-name }}
-        COPY_SETTINGS: ${{ inputs.copy-settings }}
-        MAIN_THEME_IDS: ${{ inputs.main-theme-id }}
-        THEME_ENV: ${{ inputs.theme-env }}
-        SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
-        WORK_DIR: ${{ inputs.theme-files-location }}
-        PRD_PARAMETER: ${{ inputs.is-prd }}
-      run: |
-        if [[ "${{ inputs.current-branch-name }}" == 'main' ]]; then
-          ${{ github.action_path }}/scripts/DeployMain.sh
-        fi
-      shell: bash
+    # - name: Deploy Main
+    #   env:
+    #     STORE_NAME: ${{ inputs.store-name }}
+    #     BRANCH_NAME: ${{ inputs.current-branch-name }}
+    #     COPY_SETTINGS: ${{ inputs.copy-settings }}
+    #     MAIN_THEME_IDS: ${{ inputs.main-theme-id }}
+    #     THEME_ENV: ${{ inputs.theme-env }}
+    #     SHOPIFY_API_VERSION: ${{ inputs.shopify-api-version }}
+    #     WORK_DIR: ${{ inputs.theme-files-location }}
+    #     PRD_PARAMETER: ${{ inputs.is-prd }}
+    #   run: |
+    #     if [[ "${{ inputs.current-branch-name }}" == 'main' ]]; then
+    #       ${{ github.action_path }}/scripts/DeployMain.sh
+    #     fi
+    #   shell: bash

--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,6 @@ runs:
         fi
       shell: bash
 
-
     - name: Deploy Main
       env:
         STORE_NAME: ${{ inputs.store-name }}

--- a/scripts/DeleteInactiveThemes.sh
+++ b/scripts/DeleteInactiveThemes.sh
@@ -28,20 +28,20 @@ function delete_inactive_themes() {
     
             THEME=$(echo -n "${THEME}" | tr -d '[:space:]')
             
-            # RESPONSE=$(curl -s -w "\n%{http_code}" -d "{\"theme\":{\"id\": \"${THEME_ID}\",\"name\":\"${THEME}\"}}" \
-            # -X DELETE "https://${STORE_NAME}/admin/api/${SHOPIFY_API_VERSION}/themes/${THEME_ID}.json" \
-            # -H "X-Shopify-Access-Token: ${THEMEKIT_PASSWORD}" \
-            # -H "Content-Type: application/json")
+            RESPONSE=$(curl -s -w "\n%{http_code}" -d "{\"theme\":{\"id\": \"${THEME_ID}\",\"name\":\"${THEME}\"}}" \
+            -X DELETE "https://${STORE_NAME}/admin/api/${SHOPIFY_API_VERSION}/themes/${THEME_ID}.json" \
+            -H "X-Shopify-Access-Token: ${THEMEKIT_PASSWORD}" \
+            -H "Content-Type: application/json")
             
-            # RESPONSE_BODY=$(echo "$RESPONSE" | sed '$d')
-            # HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+            RESPONSE_BODY=$(echo "$RESPONSE" | sed '$d')
+            HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
 
-            # if [[ $HTTP_CODE == "200" ]]; then
-            #     echo "Successfully deleted theme PR:${THEME} with ID:${THEME_ID} from ${STORE_NAME}"
-            # else
-            #     echo "Failed to delete theme PR:${THEME} with ID:${THEME_ID} from ${STORE_NAME}. Response code: ${HTTP_CODE}"
-            #     echo "Response body: ${RESPONSE_BODY}"
-            # fi
+            if [[ $HTTP_CODE == "200" ]]; then
+                echo "Successfully deleted theme PR:${THEME} with ID:${THEME_ID} from ${STORE_NAME}"
+            else
+                echo "Failed to delete theme PR:${THEME} with ID:${THEME_ID} from ${STORE_NAME}. Response code: ${HTTP_CODE}"
+                echo "Response body: ${RESPONSE_BODY}"
+            fi
         fi
     done
 }

--- a/scripts/DeleteInactiveThemes.sh
+++ b/scripts/DeleteInactiveThemes.sh
@@ -40,10 +40,11 @@ function delete_inactive_themes() {
                 echo "Failed to delete theme PR:${THEME} with ID:${THEME_ID} from ${STORE_NAME}. Response code: ${HTTP_CODE}"
                 echo "Response body: ${RESPONSE_BODY}"
             fi
-        fi
+            
         else
-            echo "No GitHub themes to delete on ${STORE_NAME}"
+            echo "No GitHub themes to delete on ${STORE_NAME}"    
         fi
+        
     done
 }
 

--- a/scripts/DeleteInactiveThemes.sh
+++ b/scripts/DeleteInactiveThemes.sh
@@ -3,11 +3,13 @@
 function delete_inactive_themes() {
     STORE_NAME=$1
 
-    if [[ -n $WORK_DIR ]] #only change dir if theme files are in a different folder than root
+    if [[ -n $WORK_DIR ]] # only change dir if theme files are in a different folder than root
     then
         echo "WORK_DIR ${WORK_DIR}"
         cd $WORK_DIR
     fi  
+    cat config.yml
+    ls
 
     THEMEKIT_PASSWORD=`grep -E 'password:\s*.*' config.yml | sed 's/.*password:\s*//'`
 
@@ -26,20 +28,20 @@ function delete_inactive_themes() {
     
             THEME=$(echo -n "${THEME}" | tr -d '[:space:]')
             
-            RESPONSE=$(curl -s -w "\n%{http_code}" -d "{\"theme\":{\"id\": \"${THEME_ID}\",\"name\":\"${THEME}\"}}" \
-            -X DELETE "https://${STORE_NAME}/admin/api/${SHOPIFY_API_VERSION}/themes/${THEME_ID}.json" \
-            -H "X-Shopify-Access-Token: ${THEMEKIT_PASSWORD}" \
-            -H "Content-Type: application/json")
+            # RESPONSE=$(curl -s -w "\n%{http_code}" -d "{\"theme\":{\"id\": \"${THEME_ID}\",\"name\":\"${THEME}\"}}" \
+            # -X DELETE "https://${STORE_NAME}/admin/api/${SHOPIFY_API_VERSION}/themes/${THEME_ID}.json" \
+            # -H "X-Shopify-Access-Token: ${THEMEKIT_PASSWORD}" \
+            # -H "Content-Type: application/json")
             
-            RESPONSE_BODY=$(echo "$RESPONSE" | sed '$d')
-            HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+            # RESPONSE_BODY=$(echo "$RESPONSE" | sed '$d')
+            # HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
 
-            if [[ $HTTP_CODE == "200" ]]; then
-                echo "Successfully deleted theme PR:${THEME} with ID:${THEME_ID} from ${STORE_NAME}"
-            else
-                echo "Failed to delete theme PR:${THEME} with ID:${THEME_ID} from ${STORE_NAME}. Response code: ${HTTP_CODE}"
-                echo "Response body: ${RESPONSE_BODY}"
-            fi
+            # if [[ $HTTP_CODE == "200" ]]; then
+            #     echo "Successfully deleted theme PR:${THEME} with ID:${THEME_ID} from ${STORE_NAME}"
+            # else
+            #     echo "Failed to delete theme PR:${THEME} with ID:${THEME_ID} from ${STORE_NAME}. Response code: ${HTTP_CODE}"
+            #     echo "Response body: ${RESPONSE_BODY}"
+            # fi
         fi
     done
 }

--- a/scripts/DeleteInactiveThemes.sh
+++ b/scripts/DeleteInactiveThemes.sh
@@ -27,13 +27,6 @@ function delete_inactive_themes() {
             THEME_ID=`theme get --list --password=${THEMEKIT_PASSWORD} --store="${STORE_NAME}" | grep -i ${THEME} | cut -d "[" -f 2 | cut -d "]" -f 1`
     
             THEME=$(echo -n "${THEME}" | tr -d '[:space:]')
-
-            RRRR=$(curl -X GET "https://${STORE_NAME}/admin/api/${SHOPIFY_API_VERSION}/themes.json" \
-                -H "X-Shopify-Access-Token: ${THEMEKIT_PASSWORD}" \
-                -H "Content-Type: application/json")
-
-            echo "RRRR: ${RRRR}"    
-
             
             RESPONSE=$(curl --fail --show-error -s -w "\n%{http_code}" -d "{\"theme\":{\"id\": \"${THEME_ID}\",\"name\":\"${THEME}\"}}" \
             -X DELETE "https://${STORE_NAME}/admin/api/${SHOPIFY_API_VERSION}/themes/${THEME_ID}.json" \

--- a/scripts/DeleteInactiveThemes.sh
+++ b/scripts/DeleteInactiveThemes.sh
@@ -8,10 +8,8 @@ function delete_inactive_themes() {
         echo "WORK_DIR ${WORK_DIR}"
         cd $WORK_DIR
     fi  
-    cat config.yml
-    ls
 
-    THEMEKIT_PASSWORD=`grep -E 'password:\s*.*' config.yml | sed 's/.*password:\s*//'`
+    THEMEKIT_PASSWORD=$(grep -E 'password:\s*.*' config.yml | head -n 1 | sed 's/.*password:\s*//')
 
     # grab all the themes except for main and sandboxes as we dont want to delete theme
     THEME_NAMES=`theme get --list --password=${THEMEKIT_PASSWORD} --store="${STORE_NAME}" | grep 'PR: ' | awk '{print $3}'`
@@ -28,7 +26,7 @@ function delete_inactive_themes() {
     
             THEME=$(echo -n "${THEME}" | tr -d '[:space:]')
             
-            RESPONSE=$(curl --fail --show-error -s -w "\n%{http_code}" -d "{\"theme\":{\"id\": \"${THEME_ID}\",\"name\":\"${THEME}\"}}" \
+            RESPONSE=$(curl -s -w "\n%{http_code}" -d "{\"theme\":{\"id\": \"${THEME_ID}\",\"name\":\"${THEME}\"}}" \
             -X DELETE "https://${STORE_NAME}/admin/api/${SHOPIFY_API_VERSION}/themes/${THEME_ID}.json" \
             -H "X-Shopify-Access-Token: ${THEMEKIT_PASSWORD}" \
             -H "Content-Type: application/json")

--- a/scripts/DeleteInactiveThemes.sh
+++ b/scripts/DeleteInactiveThemes.sh
@@ -27,8 +27,15 @@ function delete_inactive_themes() {
             THEME_ID=`theme get --list --password=${THEMEKIT_PASSWORD} --store="${STORE_NAME}" | grep -i ${THEME} | cut -d "[" -f 2 | cut -d "]" -f 1`
     
             THEME=$(echo -n "${THEME}" | tr -d '[:space:]')
+
+            RRRR=$(curl -X GET "https://${STORE_NAME}/admin/api/${SHOPIFY_API_VERSION}/themes.json" \
+                -H "X-Shopify-Access-Token: ${THEMEKIT_PASSWORD}" \
+                -H "Content-Type: application/json")
+
+            echo "RRRR: ${RRRR}"    
+
             
-            RESPONSE=$(curl -s -w "\n%{http_code}" -d "{\"theme\":{\"id\": \"${THEME_ID}\",\"name\":\"${THEME}\"}}" \
+            RESPONSE=$(curl --fail --show-error -s -w "\n%{http_code}" -d "{\"theme\":{\"id\": \"${THEME_ID}\",\"name\":\"${THEME}\"}}" \
             -X DELETE "https://${STORE_NAME}/admin/api/${SHOPIFY_API_VERSION}/themes/${THEME_ID}.json" \
             -H "X-Shopify-Access-Token: ${THEMEKIT_PASSWORD}" \
             -H "Content-Type: application/json")

--- a/scripts/DeleteInactiveThemes.sh
+++ b/scripts/DeleteInactiveThemes.sh
@@ -5,7 +5,7 @@ function delete_inactive_themes() {
 
     if [[ -n $WORK_DIR ]] # only change dir if theme files are in a different folder than root
     then
-        echo "WORK_DIR ${WORK_DIR}"
+        echo "==== WORK_DIR ${WORK_DIR} ===="
         cd $WORK_DIR
     fi  
 
@@ -21,7 +21,7 @@ function delete_inactive_themes() {
     for THEME in "${THEME_LIST[@]}"
     do    
         if [[ ! "${BRANCH_NAMES[*]}" =~ "${THEME}" ]]; then
-            echo "Themes that will be deleted PR:${THEME} on ${STORE_NAME}"
+            echo "==== Themes that will be deleted PR:${THEME} on ${STORE_NAME} ===="
             THEME_ID=`theme get --list --password=${THEMEKIT_PASSWORD} --store="${STORE_NAME}" | grep -i ${THEME} | cut -d "[" -f 2 | cut -d "]" -f 1`
     
             THEME=$(echo -n "${THEME}" | tr -d '[:space:]')
@@ -37,12 +37,12 @@ function delete_inactive_themes() {
             if [[ $HTTP_CODE == "200" ]]; then
                 echo "Successfully deleted theme PR:${THEME} with ID:${THEME_ID} from ${STORE_NAME}"
             else
-                echo "Failed to delete theme PR:${THEME} with ID:${THEME_ID} from ${STORE_NAME}. Response code: ${HTTP_CODE}"
-                echo "Response body: ${RESPONSE_BODY}"
+                echo "==== Failed to delete theme PR:${THEME} with ID:${THEME_ID} from ${STORE_NAME}. Response code: ${HTTP_CODE}"
+                echo "==== Response body: ${RESPONSE_BODY} ===="
             fi
             
         else
-            echo "No GitHub themes to delete on ${STORE_NAME}"    
+            echo "==== No GitHub themes to delete on ${STORE_NAME} ==== "    
         fi
         
     done

--- a/scripts/DeleteInactiveThemes.sh
+++ b/scripts/DeleteInactiveThemes.sh
@@ -41,6 +41,9 @@ function delete_inactive_themes() {
                 echo "Response body: ${RESPONSE_BODY}"
             fi
         fi
+        else
+            echo "No GitHub themes to delete on ${STORE_NAME}"
+        fi
     done
 }
 

--- a/scripts/DeployMain.sh
+++ b/scripts/DeployMain.sh
@@ -4,7 +4,7 @@ function deploy_main_branch(){
   STORE_NAME=$1
   PUBLISH_TEXT=""
 
-  # only change dir if theme files are in a different folder than root
+  # Only change dir if theme files are in a different folder than root
   if [[ -n $WORK_DIR ]] 
   then
       echo "WORK_DIR ${WORK_DIR}"
@@ -23,7 +23,7 @@ function deploy_main_branch(){
   fi
 
   TIME=$(TZ='US/Pacific' date '+%b %d %H:%M %Z %Y')  # Shortened date format
-  NEW_THEME_NAME="GitHub-${BRANCH_NAME^^}"  # Add GitHub- prefix
+  NEW_THEME_NAME="GITHUB-${BRANCH_NAME^^}"  # Add GitHub- prefix
 
   # This will rename the theme
   echo "Rename theme"

--- a/scripts/DeployMain.sh
+++ b/scripts/DeployMain.sh
@@ -7,7 +7,7 @@ function deploy_main_branch(){
   # Only change dir if theme files are in a different folder than root
   if [[ -n $WORK_DIR ]] 
   then
-      echo "WORK_DIR ${WORK_DIR}"
+      echo "==== WORK_DIR ${WORK_DIR} ===="
       cd $WORK_DIR
   fi  
 
@@ -20,7 +20,7 @@ function deploy_main_branch(){
   theme -e downloadPublishedSettings download --live
   STATUS1=$?
   if [[ $STATUS1 -ne 0 ]]; then
-      echo "Failing deployment due to error in downloading live theme settings"
+      echo "==== Failing deployment due to error in downloading live theme settings ===="
       exit $STATUS1
   fi
 
@@ -34,21 +34,21 @@ function deploy_main_branch(){
   NEW_THEME_NAME="GITHUB-${BRANCH_NAME^^}"  # Add GitHub- prefix
 
   # This will rename the theme
-  echo "Rename theme"
+  echo "==== Rename theme ==== "
   curl -d "{\"theme\":{\"name\": \"${PUBLISH_TEXT}${NEW_THEME_NAME} ${TIME} \", \"id\": \"${MAIN_THEME_IDS}\"}}" \
       -X PUT "https://${STORE_NAME}/admin/api/${SHOPIFY_API_VERSION}/themes/${MAIN_THEME_IDS}.json" \
       -H "X-Shopify-Access-Token: ${THEMEKIT_PASSWORD}" \
       -H "Content-Type: application/json"
 
   # Deploy to main theme on Shopify
-  echo "Deploying to main theme on Shopify"
+  echo "==== Deploying to main theme on Shopify ==== "
   theme -e deployTheme deploy --allow-live; STATUS1=$?    
 
   # Return the status code of theme commands
   TOTAL=$((STATUS1 + STATUS2))
   if [[ $TOTAL != 0 ]]
     then 
-        echo "Failing deployment"
+        echo "==== Failing deployment ===="
         exit $TOTAL
     fi 
     

--- a/scripts/DeployMain.sh
+++ b/scripts/DeployMain.sh
@@ -22,7 +22,7 @@ function deploy_main_branch(){
       PUBLISH_TEXT="DON'T PUBLISH "
   fi
 
-  TIME=$(TZ='US/Pacific' date '+%a %b %d %H:%M %Z %Y')  # Format without seconds
+  TIME=$(TZ='US/Pacific' date '+%b %d %H:%M %Z %Y')  # Shortened date format
   NEW_THEME_NAME="GitHub-${BRANCH_NAME^^}"  # Add GitHub- prefix
 
   # This will rename the theme

--- a/scripts/DeployMain.sh
+++ b/scripts/DeployMain.sh
@@ -19,11 +19,11 @@ function deploy_main_branch(){
   sed -i "s/theme_id: TARGET_THEME_ID/theme_id: ${MAIN_THEME_IDS}/" config.yml
 
   if [[ -n $PRD_PARAMETER ]]; then
-      PUBLISH_TEXT="DO NOT PUBLISH-"
+      PUBLISH_TEXT="DON'T PUBLISH-"
   fi
   
   TIME=`TZ='US/Pacific' date`
-  NEW_THEME_NAME="GitHub-${BRANCH_NAME^^}"
+  NEW_THEME_NAME="Git-${BRANCH_NAME^^}"
   #This will rename the theme
   echo "Rename theme"
   curl -d "{\"theme\":{\"name\": \"${PUBLISH_TEXT}${NEW_THEME_NAME} ${TIME} \", \"id\": \"${MAIN_THEME_IDS}\"}}" \

--- a/scripts/DeployMain.sh
+++ b/scripts/DeployMain.sh
@@ -23,7 +23,7 @@ function deploy_main_branch(){
   fi
   
   TIME=`TZ='US/Pacific' date`
-  NEW_THEME_NAME="Git-${BRANCH_NAME^^}"
+  NEW_THEME_NAME="${BRANCH_NAME^^}"
   #This will rename the theme
   echo "Rename theme"
   curl -d "{\"theme\":{\"name\": \"${PUBLISH_TEXT}${NEW_THEME_NAME} ${TIME} \", \"id\": \"${MAIN_THEME_IDS}\"}}" \
@@ -34,6 +34,7 @@ function deploy_main_branch(){
   echo "check pwd and ls"
   pwd
   ls
+  cat config.yml  
   
   # Deploy to main theme on Shopify
   echo "Deploying to main theme on Shopify"

--- a/scripts/DeployMain.sh
+++ b/scripts/DeployMain.sh
@@ -16,6 +16,14 @@ function deploy_main_branch(){
   LIST=`theme get --list --password=${THEMEKIT_PASSWORD} --store="${STORE_NAME}"`
   echo "THEME LIST = ${LIST}"
 
+  echo "===== Downloading theme settings from live theme ====="
+  theme -e downloadPublishedSettings download --live
+  STATUS1=$?
+  if [[ $STATUS1 -ne 0 ]]; then
+      echo "Failing deployment due to error in downloading live theme settings"
+      exit $STATUS1
+  fi
+
   sed -i "s/theme_id: TARGET_THEME_ID/theme_id: ${MAIN_THEME_IDS}/" config.yml
 
   if [[ -n $PRD_PARAMETER ]]; then

--- a/scripts/DeployMain.sh
+++ b/scripts/DeployMain.sh
@@ -21,21 +21,17 @@ function deploy_main_branch(){
   if [[ -n $PRD_PARAMETER ]]; then
       PUBLISH_TEXT="DON'T PUBLISH "
   fi
-  
-  TIME=`TZ='US/Pacific' date`
-  NEW_THEME_NAME="${BRANCH_NAME^^}"
-  #This will rename the theme
+
+  TIME=$(TZ='US/Pacific' date '+%a %b %d %H:%M %Z %Y')  # Format without seconds
+  NEW_THEME_NAME="GitHub-${BRANCH_NAME^^}"  # Add GitHub- prefix
+
+  # This will rename the theme
   echo "Rename theme"
   curl -d "{\"theme\":{\"name\": \"${PUBLISH_TEXT}${NEW_THEME_NAME} ${TIME} \", \"id\": \"${MAIN_THEME_IDS}\"}}" \
-        -X PUT "https://${STORE_NAME}/admin/api/${SHOPIFY_API_VERSION}/themes/${MAIN_THEME_IDS}.json" \
-        -H "X-Shopify-Access-Token: ${THEMEKIT_PASSWORD}" \
-        -H "Content-Type: application/json" 
-  
-  echo "check pwd and ls"
-  pwd
-  ls
-  cat config.yml  
-  
+      -X PUT "https://${STORE_NAME}/admin/api/${SHOPIFY_API_VERSION}/themes/${MAIN_THEME_IDS}.json" \
+      -H "X-Shopify-Access-Token: ${THEMEKIT_PASSWORD}" \
+      -H "Content-Type: application/json"
+
   # Deploy to main theme on Shopify
   echo "Deploying to main theme on Shopify"
   theme -e deployTheme deploy --allow-live; STATUS1=$?    

--- a/scripts/DeployMain.sh
+++ b/scripts/DeployMain.sh
@@ -19,7 +19,7 @@ function deploy_main_branch(){
   sed -i "s/theme_id: TARGET_THEME_ID/theme_id: ${MAIN_THEME_IDS}/" config.yml
 
   if [[ -n $PRD_PARAMETER ]]; then
-      PUBLISH_TEXT="DON'T PUBLISH-"
+      PUBLISH_TEXT="DON'T PUBLISH "
   fi
   
   TIME=`TZ='US/Pacific' date`

--- a/scripts/DeployMain.sh
+++ b/scripts/DeployMain.sh
@@ -23,7 +23,7 @@ function deploy_main_branch(){
   fi
   
   TIME=`TZ='US/Pacific' date`
-  NEW_THEME_NAME="${BRANCH_NAME^^}"
+  NEW_THEME_NAME="GitHub-${BRANCH_NAME^^}"
   #This will rename the theme
   echo "Rename theme"
   curl -d "{\"theme\":{\"name\": \"${PUBLISH_TEXT}${NEW_THEME_NAME} ${TIME} \", \"id\": \"${MAIN_THEME_IDS}\"}}" \

--- a/scripts/DeployMain.sh
+++ b/scripts/DeployMain.sh
@@ -35,8 +35,9 @@ function deploy_main_branch(){
   pwd
   ls
   
-  # Deploy to live
-    theme -e deployTheme deploy --allow-live; STATUS1=$?    
+  # Deploy to main theme on Shopify
+  echo "Deploying to main theme on Shopify"
+  theme -e deployTheme deploy --allow-live; STATUS1=$?    
 
   # Return the status code of theme commands
   TOTAL=$((STATUS1 + STATUS2))

--- a/scripts/DeployMain.sh
+++ b/scripts/DeployMain.sh
@@ -11,12 +11,12 @@ function deploy_main_branch(){
       cd $WORK_DIR
   fi  
 
-  THEMEKIT_PASSWORD=`grep -E 'password:\s*.*' config.yml | sed 's/.*password:\s*//'`
+  THEMEKIT_PASSWORD=$(grep -E 'password:\s*.*' config.yml | head -n 1 | sed 's/.*password:\s*//')
   
   LIST=`theme get --list --password=${THEMEKIT_PASSWORD} --store="${STORE_NAME}"`
   echo "THEME LIST = ${LIST}"
 
-  sed -i "s/theme_id: THEME_ID/theme_id: ${MAIN_THEME_IDS}/" config.yml
+  sed -i "s/theme_id: TARGET_THEME_ID/theme_id: ${MAIN_THEME_IDS}/" config.yml
 
   if [[ -n $PRD_PARAMETER ]]; then
       PUBLISH_TEXT="DO NOT PUBLISH-"
@@ -30,9 +30,13 @@ function deploy_main_branch(){
         -X PUT "https://${STORE_NAME}/admin/api/${SHOPIFY_API_VERSION}/themes/${MAIN_THEME_IDS}.json" \
         -H "X-Shopify-Access-Token: ${THEMEKIT_PASSWORD}" \
         -H "Content-Type: application/json" 
-
+  
+  echo "check pwd and ls"
+  pwd
+  ls
+  
   # Deploy to live
-    theme -e uat deploy --allow-live; STATUS1=$?    
+    theme -e deployTheme deploy --allow-live; STATUS1=$?    
 
   # Return the status code of theme commands
   TOTAL=$((STATUS1 + STATUS2))

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -88,8 +88,10 @@ clone_published_theme() {
         exit $STATUS1
     fi
 
-    echo ">>>>>PRINT CONFIG 2"
+    echo ">>>>> PRINT CONFIG 2"
     cat config.yml
+
+    echo "The current working directory is:"
     pwd
 
     echo "===== Deploying theme ====="

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -66,7 +66,6 @@ clone_published_theme() {
     # Create temporary directory for theme cloning
     mkdir -p temp
     cp storefront/* temp/
-    #cp storefront/config.yml temp/config.yml
     cd temp || exit
 
     if [[ -z "${THEME_ID}" ]]; then
@@ -80,6 +79,10 @@ clone_published_theme() {
         echo "Created theme id=${THEME_ID}"
     fi
 
+    echo "1. Before download The current working directory is:"
+    pwd
+    ls
+
     echo "===== Download theme stuff from live theme ====="
     theme -e downloadPublishedSettings download --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" --live
     STATUS1=$?
@@ -92,7 +95,7 @@ clone_published_theme() {
     echo ">>>>> PRINT CONFIG 2"
     cat config.yml
 
-    echo "The current working directory is:"
+    echo "2. After download The current working directory is:"
     pwd
     ls
 

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -6,10 +6,7 @@ THEME_IDS=()
 
 # Extract THEMEKIT password from configuration file
 THEMEKIT_PASSWORD=$(grep -E 'password:\s*.*' storefront/config.yml | sed 's/.*password:\s*//')
-pwd
-ls
-echo ">>>>>PRINT CONFIG 1"
-cat config.yml
+
 
 # Set THEME_NAME based on TAG_NAME or fallback to BRANCH_NAME
 if [[ -n "${TAG_NAME}" ]]; then
@@ -63,6 +60,9 @@ deploy_pr_branch_or_tag() {
 clone_published_theme() {
     local STORE_NAME=$1
 
+    echo ">>>>>PRINT CONFIG 2"
+    cat config. yml
+
     # Create temporary directory for theme cloning
     mkdir -p temp
     cp storefront/config.yml temp/config.yml
@@ -89,7 +89,7 @@ clone_published_theme() {
     fi
 
     echo ">>>>>PRINT CONFIG 2"
-    cat config,yml
+    cat config. yml
 
     echo "===== Deploying theme ====="
     theme deploy --themeid="${THEME_ID}" --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -41,8 +41,8 @@ deploy_pr_branch_or_tag() {
     PREVIEW_LINK=$(theme -e downloadPublishedSettings open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
     PREVIEW_LINKS+=("Preview this PR on [${STORE_NAME}](${PREVIEW_LINK})<br>")
 
-    echo "===== Running deploy command ====="
-    theme -e deployTheme deploy
+    echo "===== Running deploy command 3 ====="
+    theme -e deployTheme deploy --themeid="${THEME_ID}"
     STATUS3=$?
 
     if [[ $STATUS3 -ne 0 ]]; then
@@ -78,10 +78,11 @@ clone_published_theme() {
     echo "PRINT CONFIG BEFORE DOWNLOAD"
     cat config.yml
 
-    THEME_NAMES=`theme get --list --password=${THEMEKIT_PASSWORD} --store="${STORE_NAME}" | grep 'PR: ' | awk '{print $3}'`
-
+    #THEME_NAMES=`theme get --list --password=${THEMEKIT_PASSWORD} --store="${STORE_NAME}" | grep 'PR: ' | awk '{print $3}'`
+    
     echo "===== Download theme stuff from live theme ====="
-    theme -e downloadPublishedSettings download --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" --live
+    # theme -e downloadPublishedSettings download --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" --live
+    theme -e downloadPublishedSettings download --live
     STATUS1=$?
 
     if [[ $STATUS1 -ne 0 ]]; then
@@ -90,13 +91,13 @@ clone_published_theme() {
     fi
 
     echo "===== Deploying theme 1 ====="
-    theme -e deployTheme deploy --themeid="${THEME_ID}" --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
+    theme -e deployTheme deploy --themeid="${THEME_ID}" #--password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
     STATUS2=$?
 
     # Retry deployment if the first attempt fails
     if [[ $STATUS2 -ne 0 ]]; then
         echo "===== Re-deploying theme 2 ====="
-        theme -e deployTheme deploy --themeid="${THEME_ID}" --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
+        theme -e deployTheme deploy --themeid="${THEME_ID}" #--password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
         STATUS3=$?
         if [[ $STATUS3 -ne 0 ]]; then
             # Generate preview link even if deployment fails

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -65,7 +65,8 @@ clone_published_theme() {
 
     # Create temporary directory for theme cloning
     mkdir -p temp
-    cp storefront/config.yml temp/config.yml
+    cp storefront/* temp/
+    #cp storefront/config.yml temp/config.yml
     cd temp || exit
 
     if [[ -z "${THEME_ID}" ]]; then
@@ -93,6 +94,7 @@ clone_published_theme() {
 
     echo "The current working directory is:"
     pwd
+    ls
 
     echo "===== Deploying theme ====="
     theme deploy --themeid="${THEME_ID}" --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -61,7 +61,7 @@ clone_published_theme() {
     local STORE_NAME=$1
 
     echo ">>>>>PRINT CONFIG 2"
-    cat config. yml
+    cat config.yml
 
     # Create temporary directory for theme cloning
     mkdir -p temp

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -37,10 +37,6 @@ deploy_pr_branch_or_tag() {
     # Update config.yml with the theme ID
     sed -i "s/theme_id: THEME_ID/theme_id: ${THEME_ID}/" config.yml
 
-    echo ">>>>>PRINT CONFIG 1"
-    ls
-    cat storefront/config.yml
-
     # Generate PR preview link
     PREVIEW_LINK=$(theme -e downloadPublishedSettings open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
     PREVIEW_LINKS+=("Preview this PR on [${STORE_NAME}](${PREVIEW_LINK})<br>")
@@ -79,10 +75,6 @@ clone_published_theme() {
         echo "Created theme id=${THEME_ID}"
     fi
 
-    echo "1. Before download The current working directory is:"
-    pwd
-    ls
-
     echo "===== Download theme stuff from live theme ====="
     theme -e downloadPublishedSettings download --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" --live
     STATUS1=$?
@@ -91,13 +83,6 @@ clone_published_theme() {
         echo "Failing deployment 1"
         exit $STATUS1
     fi
-
-    echo ">>>>> PRINT CONFIG 2"
-    cat config.yml
-
-    echo "2. After download The current working directory is:"
-    pwd
-    ls
 
     echo "===== Deploying theme ====="
     theme deploy --themeid="${THEME_ID}" --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -16,61 +16,42 @@ else
     echo "THEME_NAME: ${BRANCH_NAME}"
 fi
 
-
 deploy_pr_branch_or_tag() {
-    local STORE_NAME=$1 
+    local STORE_NAME="$1"
 
     # Get existing THEME_ID
     THEME_ID=$(theme get --list --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" | grep -i "${THEME_NAME}" | cut -d "[" -f 2 | cut -d "]" -f 1)
     echo "Existing THEME_ID=${THEME_ID}"
     
-    # Create temporary directory for theme cloning
-    mkdir -p temp
-    cp -r $WORK_DIR/* temp/
-    cd temp || exit
-
-    # # Clone the main theme for the first run before creating the new theme
-    echo "====== Cloning main theme to the new theme ====="
-    clone_published_theme "$STORE_NAME"
-
-    # Generate PR preview link
-    echo "===== Generating preview link ====="
-    PREVIEW_LINK=$(theme -e deployTheme --themeid="${THEME_ID}"  --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
-    PREVIEW_LINKS+=("Preview this PR on [${STORE_NAME}](${PREVIEW_LINK})<br>")
-
-    # Store theme ID
-    THEME_IDS+=("${THEME_ID}")
-
-    cd .. || exit  # Navigate back for the next store
-}
-
-clone_published_theme() {
-    local STORE_NAME=$1
-
+    # Create the theme if it doesn't exist
     if [[ -z "${THEME_ID}" ]]; then
-        # Create the theme if it doesn't exist
         echo "===== Creating theme ====="
         THEME_ID=$(curl -s -d "{\"theme\":{\"name\": \"PR: ${THEME_NAME}\", \"env\": \"${THEME_ENV}\"}}" \
             -X POST "https://${STORE_NAME}/admin/api/${SHOPIFY_API_VERSION}/themes.json" \
             -H "X-Shopify-Access-Token: ${THEMEKIT_PASSWORD}" \
             -H "Content-Type: application/json" | grep -o '"id":[0-9]*' | grep -o '[0-9]*')
-
-        echo "Created theme id=${THEME_ID}"
+        echo "Created theme ID=${THEME_ID}"
     fi
 
-    echo "===== Download theme stuff from live theme ====="
+    if [[ -n $WORK_DIR ]]; then  # Only change directory if theme files are in a different folder than root
+        echo "WORK_DIR: ${WORK_DIR}"
+        cd "$WORK_DIR" || exit
+    fi
+    echo "print ls"
+    ls
+
+    echo "===== Downloading theme settings from live theme ====="
     theme -e downloadPublishedSettings download --live
     STATUS1=$?
-
     if [[ $STATUS1 -ne 0 ]]; then
-        echo "Failing deployment due to download theme stuff from live theme failue"
+        echo "Failing deployment due to error in downloading live theme settings"
         exit $STATUS1
     fi
 
     # Update TARGET_THEME_ID in config.yml
     sed -i "s/theme_id: TARGET_THEME_ID/theme_id: ${THEME_ID}/" config.yml
 
-    echo "===== Deploying theme first time ====="
+    echo "===== Deploying theme for the first time ====="
     theme -e deployTheme deploy 
     STATUS2=$?
 
@@ -78,20 +59,23 @@ clone_published_theme() {
     if [[ $STATUS2 -ne 0 ]]; then
         echo "===== Re-deploying theme ====="
         theme -e deployTheme deploy 
-
         STATUS3=$?
         if [[ $STATUS3 -ne 0 ]]; then
-            # Generate preview link even if deployment fails
             echo "THEME_ID=${THEME_IDS[@]}"
             echo "preview_link=${PREVIEW_LINKS[@]}" >> "$GITHUB_OUTPUT"
             echo "theme_id=${THEME_IDS[@]}" >> "$GITHUB_OUTPUT"
-
-            echo "===== Failing deployment due to error in theme deploy ====="
+            echo "===== Failing deployment due to error in theme deployment ====="
             exit $STATUS3
         fi
     fi
 
-    cd .. || exit
+    # Generate PR preview link
+    echo "===== Generating preview link ====="
+    PREVIEW_LINK=$(theme -e deployTheme --themeid="${THEME_ID}" --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
+    PREVIEW_LINKS+=("Preview this PR on [${STORE_NAME}](${PREVIEW_LINK})<br>")
+    THEME_IDS+=("${THEME_ID}")
+
+    cd .. || exit 1  # Navigate back for the next store
 }
 
 # Iterate over stores and deploy the theme

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -37,7 +37,7 @@ deploy_pr_branch_or_tag() {
 
     # Generate PR preview link
     echo "===== Generating preview link ====="
-    PREVIEW_LINK=$(theme -e deployTheme --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
+    PREVIEW_LINK=$(theme -e deployTheme --themeid="${THEME_ID}"  --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
     theme -e deployTheme open -b /bin/echo | grep -i "${STORE_NAME}"
     theme -e deployTheme open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}'
     PREVIEW_LINKS+=("Preview this PR on [${STORE_NAME}](${PREVIEW_LINK})<br>")

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -10,10 +10,10 @@ THEMEKIT_PASSWORD=$(grep -E 'password:\s*.*' storefront/config.yml | head -n 1 |
 
 # Set THEME_NAME based on TAG_NAME or fallback to BRANCH_NAME
 if [[ -n "${TAG_NAME}" ]]; then
-    THEME_NAME="${TAG_NAME}"
+    THEME_NAME="==== ${TAG_NAME} ===="
 else 
     THEME_NAME="${BRANCH_NAME}"
-    echo "THEME_NAME: ${BRANCH_NAME}"
+    echo "==== THEME_NAME: ${BRANCH_NAME} ===="
 fi
 
 deploy_pr_branch_or_tag() {
@@ -21,7 +21,7 @@ deploy_pr_branch_or_tag() {
 
     # Get existing THEME_ID
     THEME_ID=$(theme get --list --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" | grep -i "${THEME_NAME}" | cut -d "[" -f 2 | cut -d "]" -f 1)
-    echo "Existing THEME_ID=${THEME_ID}"
+    echo "==== Existing THEME_ID=${THEME_ID} ===="
     
     # Create the theme if it doesn't exist
     if [[ -z "${THEME_ID}" ]]; then
@@ -34,7 +34,7 @@ deploy_pr_branch_or_tag() {
     fi
 
     if [[ -n $WORK_DIR ]]; then  # Only change directory if theme files are in a different folder than root
-        echo "WORK_DIR: ${WORK_DIR}"
+        echo "==== WORK_DIR: ${WORK_DIR} ===="
         cd "$WORK_DIR" || exit
     fi
 
@@ -42,7 +42,7 @@ deploy_pr_branch_or_tag() {
     theme -e downloadPublishedSettings download --live
     STATUS1=$?
     if [[ $STATUS1 -ne 0 ]]; then
-        echo "Failing deployment due to error in downloading live theme settings"
+        echo "==== Failing deployment due to error in downloading live theme settings"
         exit $STATUS1
     fi
 

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -75,6 +75,7 @@ clone_published_theme() {
         echo "Created theme id=${THEME_ID}"
     fi
 
+    sed -i "s/theme_id: TARGET_THEME_ID/theme_id: ${THEME_ID}/" config.yml
     echo "PRINT CONFIG BEFORE DOWNLOAD"
     cat config.yml
 
@@ -91,13 +92,13 @@ clone_published_theme() {
     fi
 
     echo "===== Deploying theme 1 ====="
-    theme -e deployTheme deploy --themeid="${THEME_ID}" #--password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
+    theme -e deployTheme deploy # --themeid="${THEME_ID}" #--password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
     STATUS2=$?
 
     # Retry deployment if the first attempt fails
     if [[ $STATUS2 -ne 0 ]]; then
         echo "===== Re-deploying theme 2 ====="
-        theme -e deployTheme deploy --themeid="${THEME_ID}" #--password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
+        theme -e deployTheme deploy #--themeid="${THEME_ID}" #--password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
         STATUS3=$?
         if [[ $STATUS3 -ne 0 ]]; then
             # Generate preview link even if deployment fails

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -15,40 +15,40 @@ else
     echo "THEME_NAME: ${BRANCH_NAME}"
 fi
 
-# Get existing THEME_ID
-THEME_ID=$(theme get --list --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" | grep -i "${THEME_NAME}" | cut -d "[" -f 2 | cut -d "]" -f 1)
-echo "Existing THEME_ID=${THEME_ID}"
+# # Get existing THEME_ID
+# THEME_ID=$(theme get --list --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" | grep -i "${THEME_NAME}" | cut -d "[" -f 2 | cut -d "]" -f 1)
+# echo "Existing THEME_ID=${THEME_ID}"
 
 deploy_pr_branch_or_tag() {
     local STORE_NAME=$1 
 
-    # Clone the main theme for the first run before creatig the new theme
-    echo "RUN_ID is ${RUN_ID}"
-    if [[ $RUN_ID -lt 2 ]]; then
+    # # Clone the main theme for the first run before creatig the new theme
+    # echo "RUN_ID is ${RUN_ID}"
+    # if [[ $RUN_ID -lt 2 ]]; then
     echo "====== Cloning main theme to the new theme ====="
     clone_published_theme "$STORE_NAME"
-    fi
+    # fi
 
-    if [[ -n $WORK_DIR ]]; then  # Only change directory if theme files are in a different folder than root
-        echo "WORK_DIR: ${WORK_DIR}"
-        cd "$WORK_DIR" || exit
-    fi
+    # if [[ -n $WORK_DIR ]]; then  # Only change directory if theme files are in a different folder than root
+    #     echo "WORK_DIR: ${WORK_DIR}"
+    #     cd "$WORK_DIR" || exit
+    # fi
 
-    # Update config.yml with the theme ID
-    sed -i "s/theme_id: THEME_ID/theme_id: ${THEME_ID}/" config.yml
+    # # Update config.yml with the theme ID
+    # sed -i "s/theme_id: THEME_ID/theme_id: ${THEME_ID}/" config.yml
 
     # Generate PR preview link
     PREVIEW_LINK=$(theme -e downloadPublishedSettings open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
     PREVIEW_LINKS+=("Preview this PR on [${STORE_NAME}](${PREVIEW_LINK})<br>")
 
-    echo "===== Running deploy command 3 ====="
-    theme -e deployTheme deploy --themeid="${THEME_ID}"
-    STATUS3=$?
+    # echo "===== Running deploy command 3 ====="
+    # theme -e deployTheme deploy --themeid="${THEME_ID}"
+    # STATUS3=$?
 
-    if [[ $STATUS3 -ne 0 ]]; then
-        echo "===== Failing deployment 3 ====="
-        exit $STATUS3
-    fi
+    # if [[ $STATUS3 -ne 0 ]]; then
+    #     echo "===== Failing deployment 3 ====="
+    #     exit $STATUS3
+    # fi
 
     # Store theme ID
     THEME_IDS+=("${THEME_ID}")
@@ -61,7 +61,7 @@ clone_published_theme() {
 
     # Create temporary directory for theme cloning
     mkdir -p temp
-    cp -r storefront/* temp/
+    cp -r $WORK_DIR/* temp/
     cd temp || exit
 
     if [[ -z "${THEME_ID}" ]]; then

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -35,10 +35,9 @@ deploy_pr_branch_or_tag() {
     echo "====== Cloning main theme to the new theme ====="
     clone_published_theme "$STORE_NAME"
 
-
     # Generate PR preview link
     echo "===== Generating preview link ====="
-    PREVIEW_LINK=$(theme -e deployTheme open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
+    PREVIEW_LINK=$(theme -e deployTheme --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
     theme -e deployTheme open -b /bin/echo | grep -i "${STORE_NAME}"
     theme -e deployTheme open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}'
     PREVIEW_LINKS+=("Preview this PR on [${STORE_NAME}](${PREVIEW_LINK})<br>")

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -92,13 +92,13 @@ clone_published_theme() {
     fi
 
     echo "===== Deploying theme 1 ====="
-    theme -e deployTheme deploy # --themeid="${THEME_ID}" #--password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
+    theme -e deployTheme deploy 
     STATUS2=$?
 
     # Retry deployment if the first attempt fails
     if [[ $STATUS2 -ne 0 ]]; then
         echo "===== Re-deploying theme 2 ====="
-        theme -e deployTheme deploy #--themeid="${THEME_ID}" #--password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
+        theme -e deployTheme deploy 
         STATUS3=$?
         if [[ $STATUS3 -ne 0 ]]; then
             # Generate preview link even if deployment fails

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -25,9 +25,9 @@ deploy_pr_branch_or_tag() {
 
     # Generate PR preview link
     echo "===== Generating preview link ====="
-    PREVIEW_LINK=$(theme -e deploy open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
-    theme -e deploy open -b /bin/echo | grep -i "${STORE_NAME}"
-    theme -e deploy open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}'
+    PREVIEW_LINK=$(theme -e deployTheme open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
+    theme -e deployTheme open -b /bin/echo | grep -i "${STORE_NAME}"
+    theme -e deployTheme open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}'
     PREVIEW_LINKS+=("Preview this PR on [${STORE_NAME}](${PREVIEW_LINK})<br>")
 
     # Store theme ID

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -63,9 +63,6 @@ deploy_pr_branch_or_tag() {
 clone_published_theme() {
     local STORE_NAME=$1
 
-    echo ">>>>>PRINT CONFIG 2"
-    cat storefront/config.yml
-
     # Create temporary directory for theme cloning
     mkdir -p temp
     cp storefront/config.yml temp/config.yml
@@ -82,7 +79,7 @@ clone_published_theme() {
         echo "Created theme id=${THEME_ID}"
     fi
 
-    # Download the theme
+    echo "===== Download theme stuff from live theme ====="
     theme -e downloadPublishedSettings download --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" --live
     STATUS1=$?
 
@@ -92,7 +89,8 @@ clone_published_theme() {
     fi
 
     echo ">>>>>PRINT CONFIG 2"
-    cat config. yml
+    cat config.yml
+    pwd
 
     echo "===== Deploying theme ====="
     theme deploy --themeid="${THEME_ID}" --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -8,7 +8,7 @@ THEME_IDS=()
 THEMEKIT_PASSWORD=$(grep -E 'password:\s*.*' storefront/config.yml | sed 's/.*password:\s*//')
 
 echo ">>>>>PRINT CONFIG 1"
-cat config,yml
+cat config.yml
 
 # Set THEME_NAME based on TAG_NAME or fallback to BRANCH_NAME
 if [[ -n "${TAG_NAME}" ]]; then
@@ -89,7 +89,7 @@ clone_published_theme() {
 
     echo ">>>>>PRINT CONFIG 2"
     cat config,yml
-    
+
     echo "===== Deploying theme ====="
     theme deploy --themeid="${THEME_ID}" --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
     STATUS2=$?

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -65,7 +65,7 @@ clone_published_theme() {
 
     # Create temporary directory for theme cloning
     mkdir -p temp
-    cp storefront/* temp/
+    cp -r storefront/* temp/
     cd temp || exit
 
     if [[ -z "${THEME_ID}" ]]; then

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -15,8 +15,16 @@ else
     echo "THEME_NAME: ${BRANCH_NAME}"
 fi
 
+
 deploy_pr_branch_or_tag() {
     local STORE_NAME=$1 
+
+    # Get existing THEME_ID
+    THEME_ID=$(theme get --list --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" | grep -i "${THEME_NAME}" | cut -d "[" -f 2 | cut -d "]" -f 1)
+    echo "Existing THEME_ID=${THEME_ID}"
+
+    # Update TARGET_THEME_ID in config.yml
+    sed -i "s/theme_id: TARGET_THEME_ID/theme_id: ${THEME_ID}/" config.yml
 
     # # Clone the main theme for the first run before creating the new theme
     echo "====== Cloning main theme to the new theme ====="
@@ -64,7 +72,7 @@ clone_published_theme() {
         exit $STATUS1
     fi
 
-    sed -i "s/theme_id: TARGET_THEME_ID/theme_id: ${THEME_ID}/" config.yml # Update TARGET_THEME_ID in config.yml
+    ## Old Sed for theme ID 
 
     echo "===== Deploying theme first time ====="
     theme -e deployTheme deploy 
@@ -74,6 +82,7 @@ clone_published_theme() {
     if [[ $STATUS2 -ne 0 ]]; then
         echo "===== Re-deploying theme ====="
         theme -e deployTheme deploy 
+        
         STATUS3=$?
         if [[ $STATUS3 -ne 0 ]]; then
             # Generate preview link even if deployment fails

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -6,7 +6,8 @@ THEME_IDS=()
 
 # Extract THEMEKIT password from configuration file
 THEMEKIT_PASSWORD=$(grep -E 'password:\s*.*' storefront/config.yml | sed 's/.*password:\s*//')
-
+pwd
+ls
 echo ">>>>>PRINT CONFIG 1"
 cat config.yml
 

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -10,7 +10,7 @@ THEMEKIT_PASSWORD=$(grep -E 'password:\s*.*' storefront/config.yml | head -n 1 |
 # Set THEME_NAME based on TAG_NAME or fallback to BRANCH_NAME
 if [[ -n "${TAG_NAME}" ]]; then
     THEME_NAME="${TAG_NAME}"
-else
+else 
     THEME_NAME="${BRANCH_NAME}"
     echo "THEME_NAME: ${BRANCH_NAME}"
 fi
@@ -42,7 +42,7 @@ deploy_pr_branch_or_tag() {
     PREVIEW_LINKS+=("Preview this PR on [${STORE_NAME}](${PREVIEW_LINK})<br>")
 
     echo "===== Running deploy command ====="
-    theme -e downloadPublishedSettings deploy
+    theme -e deployTheme deploy
     STATUS3=$?
 
     if [[ $STATUS3 -ne 0 ]]; then
@@ -75,6 +75,11 @@ clone_published_theme() {
         echo "Created theme id=${THEME_ID}"
     fi
 
+    echo "PRINT CONFIG BEFORE DOWNLOAD"
+    cat config.yml
+
+    THEME_NAMES=`theme get --list --password=${THEMEKIT_PASSWORD} --store="${STORE_NAME}" | grep 'PR: ' | awk '{print $3}'`
+
     echo "===== Download theme stuff from live theme ====="
     theme -e downloadPublishedSettings download --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" --live
     STATUS1=$?
@@ -84,14 +89,14 @@ clone_published_theme() {
         exit $STATUS1
     fi
 
-    echo "===== Deploying theme ====="
-    theme deploy --themeid="${THEME_ID}" --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
+    echo "===== Deploying theme 1 ====="
+    theme -e deployTheme deploy --themeid="${THEME_ID}" --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
     STATUS2=$?
 
-     # Retry deployment if the first attempt fails
+    # Retry deployment if the first attempt fails
     if [[ $STATUS2 -ne 0 ]]; then
-        echo "===== Re-deploying theme ====="
-        theme deploy --themeid="${THEME_ID}" --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
+        echo "===== Re-deploying theme 2 ====="
+        theme -e deployTheme deploy --themeid="${THEME_ID}" --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
         STATUS3=$?
         if [[ $STATUS3 -ne 0 ]]; then
             # Generate preview link even if deployment fails

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -5,8 +5,7 @@ PREVIEW_LINKS=()
 THEME_IDS=()
 
 # Extract THEMEKIT password from configuration file
-THEMEKIT_PASSWORD=$(grep -E 'password:\s*.*' storefront/config.yml | sed 's/.*password:\s*//')
-
+THEMEKIT_PASSWORD=$(grep -E 'password:\s*.*' storefront/config.yml | head -n 1 | sed 's/.*password:\s*//')
 
 # Set THEME_NAME based on TAG_NAME or fallback to BRANCH_NAME
 if [[ -n "${TAG_NAME}" ]]; then

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -7,7 +7,7 @@ THEME_IDS=()
 # Extract THEMEKIT password from configuration file
 THEMEKIT_PASSWORD=$(grep -E 'password:\s*.*' storefront/config.yml | sed 's/.*password:\s*//')
 
-echo "PRINT CONFIG"
+echo ">>>>>PRINT CONFIG 1"
 cat config,yml
 
 # Set THEME_NAME based on TAG_NAME or fallback to BRANCH_NAME
@@ -87,6 +87,9 @@ clone_published_theme() {
         exit $STATUS1
     fi
 
+    echo ">>>>>PRINT CONFIG 2"
+    cat config,yml
+    
     echo "===== Deploying theme ====="
     theme deploy --themeid="${THEME_ID}" --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}"
     STATUS2=$?

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -37,8 +37,6 @@ deploy_pr_branch_or_tag() {
         echo "WORK_DIR: ${WORK_DIR}"
         cd "$WORK_DIR" || exit
     fi
-    echo "print ls"
-    ls
 
     echo "===== Downloading theme settings from live theme ====="
     theme -e downloadPublishedSettings download --live
@@ -48,7 +46,7 @@ deploy_pr_branch_or_tag() {
         exit $STATUS1
     fi
 
-    # Update TARGET_THEME_ID in config.yml
+    # Update TARGET_THEME_ID in config.yml with the new THEME_ID
     sed -i "s/theme_id: TARGET_THEME_ID/theme_id: ${THEME_ID}/" config.yml
 
     echo "===== Deploying theme for the first time ====="

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -3,6 +3,7 @@
 # Initialize arrays for preview links and theme IDs
 PREVIEW_LINKS=()
 THEME_IDS=()
+THEME_ID=""
 
 # Extract THEMEKIT password from configuration file
 THEMEKIT_PASSWORD=$(grep -E 'password:\s*.*' storefront/config.yml | head -n 1 | sed 's/.*password:\s*//')
@@ -28,9 +29,6 @@ deploy_pr_branch_or_tag() {
     cp -r $WORK_DIR/* temp/
     cd temp || exit
 
-    # Update TARGET_THEME_ID in config.yml
-    sed -i "s/theme_id: TARGET_THEME_ID/theme_id: ${THEME_ID}/" config.yml
-
     # # Clone the main theme for the first run before creating the new theme
     echo "====== Cloning main theme to the new theme ====="
     clone_published_theme "$STORE_NAME"
@@ -38,8 +36,6 @@ deploy_pr_branch_or_tag() {
     # Generate PR preview link
     echo "===== Generating preview link ====="
     PREVIEW_LINK=$(theme -e deployTheme --themeid="${THEME_ID}"  --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
-    theme -e deployTheme open -b /bin/echo | grep -i "${STORE_NAME}"
-    theme -e deployTheme open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}'
     PREVIEW_LINKS+=("Preview this PR on [${STORE_NAME}](${PREVIEW_LINK})<br>")
 
     # Store theme ID
@@ -71,7 +67,8 @@ clone_published_theme() {
         exit $STATUS1
     fi
 
-    ## Old Sed for theme ID 
+    # Update TARGET_THEME_ID in config.yml
+    sed -i "s/theme_id: TARGET_THEME_ID/theme_id: ${THEME_ID}/" config.yml
 
     echo "===== Deploying theme first time ====="
     theme -e deployTheme deploy 

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -38,6 +38,10 @@ deploy_pr_branch_or_tag() {
     # Update config.yml with the theme ID
     sed -i "s/theme_id: THEME_ID/theme_id: ${THEME_ID}/" config.yml
 
+    echo ">>>>>PRINT CONFIG 1"
+    ls
+    cat config.yml
+
     # Generate PR preview link
     PREVIEW_LINK=$(theme -e downloadPublishedSettings open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
     PREVIEW_LINKS+=("Preview this PR on [${STORE_NAME}](${PREVIEW_LINK})<br>")

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -40,7 +40,7 @@ deploy_pr_branch_or_tag() {
 
     echo ">>>>>PRINT CONFIG 1"
     ls
-    cat config.yml
+    cat storefront/config.yml
 
     # Generate PR preview link
     PREVIEW_LINK=$(theme -e downloadPublishedSettings open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
@@ -65,7 +65,7 @@ clone_published_theme() {
     local STORE_NAME=$1
 
     echo ">>>>>PRINT CONFIG 2"
-    cat config.yml
+    cat storefront/config.yml
 
     # Create temporary directory for theme cloning
     mkdir -p temp

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -22,6 +22,11 @@ deploy_pr_branch_or_tag() {
     # Get existing THEME_ID
     THEME_ID=$(theme get --list --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" | grep -i "${THEME_NAME}" | cut -d "[" -f 2 | cut -d "]" -f 1)
     echo "Existing THEME_ID=${THEME_ID}"
+    
+    # Create temporary directory for theme cloning
+    mkdir -p temp
+    cp -r $WORK_DIR/* temp/
+    cd temp || exit
 
     # Update TARGET_THEME_ID in config.yml
     sed -i "s/theme_id: TARGET_THEME_ID/theme_id: ${THEME_ID}/" config.yml
@@ -46,11 +51,6 @@ deploy_pr_branch_or_tag() {
 
 clone_published_theme() {
     local STORE_NAME=$1
-
-    # Create temporary directory for theme cloning
-    mkdir -p temp
-    cp -r $WORK_DIR/* temp/
-    cd temp || exit
 
     if [[ -z "${THEME_ID}" ]]; then
         # Create the theme if it doesn't exist
@@ -82,7 +82,7 @@ clone_published_theme() {
     if [[ $STATUS2 -ne 0 ]]; then
         echo "===== Re-deploying theme ====="
         theme -e deployTheme deploy 
-        
+
         STATUS3=$?
         if [[ $STATUS3 -ne 0 ]]; then
             # Generate preview link even if deployment fails

--- a/scripts/DeployPRorTag.sh
+++ b/scripts/DeployPRorTag.sh
@@ -7,6 +7,9 @@ THEME_IDS=()
 # Extract THEMEKIT password from configuration file
 THEMEKIT_PASSWORD=$(grep -E 'password:\s*.*' storefront/config.yml | sed 's/.*password:\s*//')
 
+echo "PRINT CONFIG"
+cat config,yml
+
 # Set THEME_NAME based on TAG_NAME or fallback to BRANCH_NAME
 if [[ -n "${TAG_NAME}" ]]; then
     THEME_NAME="${TAG_NAME}"
@@ -38,11 +41,11 @@ deploy_pr_branch_or_tag() {
     sed -i "s/theme_id: THEME_ID/theme_id: ${THEME_ID}/" config.yml
 
     # Generate PR preview link
-    PREVIEW_LINK=$(theme -e uat open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
+    PREVIEW_LINK=$(theme -e downloadPublishedSettings open -b /bin/echo | grep -i "${STORE_NAME}" | awk 'END {print $3}')
     PREVIEW_LINKS+=("Preview this PR on [${STORE_NAME}](${PREVIEW_LINK})<br>")
 
     echo "===== Running deploy command ====="
-    theme -e uat deploy
+    theme -e downloadPublishedSettings deploy
     STATUS3=$?
 
     if [[ $STATUS3 -ne 0 ]]; then
@@ -76,7 +79,7 @@ clone_published_theme() {
     fi
 
     # Download the theme
-    theme download --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" --live
+    theme -e downloadPublishedSettings download --password="${THEMEKIT_PASSWORD}" --store="${STORE_NAME}" --live
     STATUS1=$?
 
     if [[ $STATUS1 -ne 0 ]]; then


### PR DESCRIPTION
Based on the [conversation we had on slack](https://satel.slack.com/archives/DF72CNMQS/p1743186080747859) about copying the settings from published theme to a PR or while deploying on Main. Now we do the below: 

- Copy settings from the published theme to a PR and only run it when it's opened. Not for any further commits 
- Pull settings from the published theme when deploying to main 
- USe different config profiles when deploying vs pulling settings
- The new config would like this 

```yml
downloadPublishedSettings: 
  password: API_KEY
  theme_id: PUBLISHED_THEME_ID
  store: STORE
  ignore_files:
    - sections/*.liquid
    - snippets/*
    - assets/*
    - config/settings_schema.json
    - layout/*
    - locales/*

deployTheme:
  password: API_KEY
  theme_id: TARGET_THEME_ID
  store: STORE
```

**NOTE:** Need to check if this will work with [Shape](https://satel.slack.com/archives/C3CTAK98B/p1709753685628279)